### PR TITLE
Fix typo in northern horse lifestage graphics

### DIFF
--- a/1.5/Defs/ThingDefs_Races/Races_Animal_CowGroup.xml
+++ b/1.5/Defs/ThingDefs_Races/Races_Animal_CowGroup.xml
@@ -146,7 +146,7 @@
       </li>
       <li>
         <bodyGraphicData>
-          <texPath>Animals/NorthernHorse</texPath>
+          <texPath>Animals/NorthernHorse/NorthernHorse</texPath>
           <drawSize>2.5</drawSize>
           <shadowData>
             <volume>(0.6, 0.45, 0.45)</volume>


### PR DESCRIPTION
Fix a minor typo in the lifestage graphics of the northern horse.

Stumbled across this issue while using a Combat Extended patch for this mod. Vanilla appears to have some kind of fallback to handle this (with a warning), but happens to throw an ugly (though minor) error with CE's hitbox generator.